### PR TITLE
mir.internal.memory: Fix _aligned_free() signature for MSVC targets

### DIFF
--- a/source/mir/internal/memory.d
+++ b/source/mir/internal/memory.d
@@ -111,7 +111,7 @@ version (Windows)
     // DMD Win 64 bit, uses microsoft standard C library which implements them
     else
     {
-        private extern(C) void* _aligned_free(void *);
+        private extern(C) void _aligned_free(void *);
         private extern(C) void* _aligned_malloc(size_t, size_t);
         private extern(C) void* _aligned_realloc(void *, size_t, size_t);
     }


### PR DESCRIPTION
LDC doesn't forgive typos (?) like this.

See https://docs.microsoft.com/en-us/cpp/c-runtime-library/reference/aligned-free?view=msvc-160.