### PR TITLE
Deprecate complex math interfaces

### DIFF
--- a/source/mir/internal/utility.d
+++ b/source/mir/internal/utility.d
@@ -32,7 +32,9 @@ template realType(C)
     alias realType = typeof(Unqual!C.init.re);
 }
 
-deprecated template isComplex(C)
+// Should be 'deprecated', but blocked by issue 21831.
+// Instead, this is explicitly undocumented.
+template isComplex(C)
 {
     import std.traits: Unqual;
     alias U = Unqual!C;

--- a/source/mir/internal/utility.d
+++ b/source/mir/internal/utility.d
@@ -18,17 +18,21 @@ template Iota(size_t i, size_t j)
 
 ///
 template realType(C)
-    if (__traits(isFloating, C) || isComplex!C)
+    if (__traits(isFloating, C) && !isComplex!C)
 {
     import std.traits: Unqual;
-    static if (isComplex!C)
-        alias realType = typeof(Unqual!C.init.re);
-    else
-        alias realType = Unqual!C;
+    alias realType = Unqual!C;
 }
 
-///
-template isComplex(C)
+deprecated("Use of complex types is deprecated. Use std.complex")
+template realType(C)
+    if (isComplex!C)
+{
+    import std.traits: Unqual;
+    alias realType = typeof(Unqual!C.init.re);
+}
+
+deprecated template isComplex(C)
 {
     import std.traits: Unqual;
     alias U = Unqual!C;

--- a/source/mir/math/common.d
+++ b/source/mir/math/common.d
@@ -8,7 +8,8 @@ Authors:   Ilya Yaroshenko, Phobos Team
 +/
 module mir.math.common;
 
-import mir.internal.utility: isComplex, isFloatingPoint;
+import mir.internal.utility: isFloatingPoint;
+deprecated import mir.internal.utility: isComplex;
 
 version(LDC)
 {
@@ -559,15 +560,14 @@ version (mir_core_test)
     assert(feqrel(pow(2.0L, -0.5L), cos(PI / 4)) >= real.mant_dig - 1);
 }
 
-/// Overload for cdouble, cfloat and creal
-@optmath auto fabs(T)(in T x)
+deprecated("Use of complex types is deprecated. Use std.complex")
+auto fabs(T)(in T x)
     if (isComplex!T)
 {
     return x.re * x.re + x.im * x.im;
 }
 
-///
-version(mir_core_test) unittest
+version(mir_core_test) deprecated unittest
 {
     assert(fabs(3 + 4i) == 25);
 }
@@ -607,29 +607,28 @@ bool approxEqual(T)(const T lhs, const T rhs, const T maxRelDiff = T(0x1p-20f), 
     assert(!approxEqual(100000.0L, 100001L));
 }
 
-/// ditto
+deprecated("Use of complex types is deprecated. Use std.complex")
 bool approxEqual(T : cfloat)(const T lhs, const T rhs, float maxRelDiff = 0x1p-20f, float maxAbsDiff = 0x1p-20f)
 {
     return approxEqual(lhs.re, rhs.re, maxRelDiff, maxAbsDiff)
         && approxEqual(lhs.im, rhs.im, maxRelDiff, maxAbsDiff);
 }
 
-/// ditto
+deprecated("Use of complex types is deprecated. Use std.complex")
 bool approxEqual(T : cdouble)(const T lhs, const T rhs, double maxRelDiff = 0x1p-20f, double maxAbsDiff = 0x1p-20f)
 {
     return approxEqual(lhs.re, rhs.re, maxRelDiff, maxAbsDiff)
         && approxEqual(lhs.im, rhs.im, maxRelDiff, maxAbsDiff);
 }
 
-/// ditto
+deprecated("Use of complex types is deprecated. Use std.complex")
 bool approxEqual(T : creal)(const T lhs, const T rhs, real maxRelDiff = 0x1p-20f, real maxAbsDiff = 0x1p-20f)
 {
     return approxEqual(lhs.re, rhs.re, maxRelDiff, maxAbsDiff)
         && approxEqual(lhs.im, rhs.im, maxRelDiff, maxAbsDiff);
 }
 
-/// Complex types works as `approxEqual(l.re, r.re) && approxEqual(l.im, r.im)`
-@safe pure nothrow @nogc version(mir_core_test) unittest
+@safe pure nothrow @nogc version(mir_core_test) deprecated unittest
 {
     assert(approxEqual(1.0 + 1i, 1.0000001 + 1.0000001i));
     assert(!approxEqual(100000.0L + 0i, 100001L + 0i));

--- a/source/mir/math/common.d
+++ b/source/mir/math/common.d
@@ -8,8 +8,7 @@ Authors:   Ilya Yaroshenko, Phobos Team
 +/
 module mir.math.common;
 
-import mir.internal.utility: isFloatingPoint;
-deprecated import mir.internal.utility: isComplex;
+import mir.internal.utility: isComplex, isFloatingPoint;
 
 version(LDC)
 {
@@ -560,11 +559,14 @@ version (mir_core_test)
     assert(feqrel(pow(2.0L, -0.5L), cos(PI / 4)) >= real.mant_dig - 1);
 }
 
-deprecated("Use of complex types is deprecated. Use std.complex")
-auto fabs(T)(in T x)
-    if (isComplex!T)
+static if (true) // Workaround issue 21830
 {
-    return x.re * x.re + x.im * x.im;
+    deprecated("Use of complex types is deprecated. Use std.complex")
+    auto fabs(T)(in T x)
+        if (isComplex!T)
+    {
+        return x.re * x.re + x.im * x.im;
+    }
 }
 
 version(mir_core_test) deprecated unittest

--- a/source/mir/math/ieee.d
+++ b/source/mir/math/ieee.d
@@ -137,7 +137,7 @@ int feqrel(T)(const T x, const T y) @trusted pure nothrow @nogc
             || realFormat == RealFormat.ieeeExtended
             || realFormat == RealFormat.ieeeQuadruple)
     {
-        import mir.math.common: fabs;
+        import mir.math.common; //: fabs // Not a selective import due to issue 21832
 
         if (x == y)
             return T.mant_dig; // ensure diff != 0, cope with IN
@@ -725,7 +725,7 @@ T frexp(T)(const T value, ref int exp) @trusted pure nothrow @nogc
 if (isFloatingPoint!T)
 {
     import mir.utility: _expect;
-    import mir.math.common: fabs;
+    import mir.math.common; //: fabs // Not a selective import due to issue 21832
 
     if (__ctfe)
     {


### PR DESCRIPTION
Sun is setting on this feature.

https://github.com/dlang/dmd/pull/12390

In typical fashion, I found a few bugs in the use of `deprecated` keyword, they are being dealt with in dlang/dmd#12440, dlang/dmd#12441, and dlang/dmd#12442 respectively.  Once they are in, the test-suite should pass.