### PR TITLE
fix unsafeEnumFromIndex returning wrong values

### DIFF
--- a/source/mir/enums.d
+++ b/source/mir/enums.d
@@ -225,12 +225,36 @@ T unsafeEnumFromIndex(T)(size_t index)
     
     static if (fastConv)
     {
-        return cast(T) index;
+        return cast(T) index + enumMembers!T[0];
     }
     else
     {
         return enumMembers!T[index];
     }
+}
+
+///
+unittest
+{
+    enum Linear
+    {
+        one = 1,
+        two = 2
+    }
+
+    assert(unsafeEnumFromIndex!Linear(0) == Linear.one);
+    assert(unsafeEnumFromIndex!Linear(1) == Linear.two);
+
+    enum Mixed
+    {
+        one = 1,
+        oneAgain = 1,
+        two = 2
+    }
+
+    assert(unsafeEnumFromIndex!Mixed(0) == Mixed.one);
+    assert(unsafeEnumFromIndex!Mixed(1) == Mixed.one);
+    assert(unsafeEnumFromIndex!Mixed(2) == Mixed.two);
 }
 
 /++


### PR DESCRIPTION
With enums not starting at 0, but linearly growing, there was a critical bug that mir-core casted the values to the enum without checking.

For example with mir-ion that would have caused an enum like

```d
@serdeProxy!int
enum Test { a = 1, b = 2 }
```

to deserialize `1` into `cast(Test)0` or more critically deserialize `2` into `Test.a`

This is due to `hasSeqGrow` testing if it grows starting at the first enum value, not starting at 0.