### PR TITLE
Use dflags "-checkaction=context" "-allinst" in unittest configurations

### DIFF
--- a/dub.sdl
+++ b/dub.sdl
@@ -8,10 +8,11 @@ license "Apache-2.0"
 buildType "unittest" {
     buildOptions "unittests" "debugMode" "debugInfo"
     versions "mir_core_test"
+    dflags "-checkaction=context" "-allinst"
 }
 
 buildType "unittest-dip1008" {
     buildOptions "unittests" "debugMode" "debugInfo"
     versions "mir_core_test"
-    dflags "-lowmem" "-preview=dip1008"
+    dflags "-lowmem" "-preview=dip1008" "-checkaction=context" "-allinst"
 }


### PR DESCRIPTION
Hmm, this fails with a linking error as

```
dub test --build=unittest
Generating test runner configuration 'mir-core-test-library' for 'library' (library).
Performing "unittest" build using /home/per/.local/ldc2-1.30.0-beta1-linux-x86_64/bin/ldc2 for x86_64.
mir-core 1.1.85: building configuration "mir-core-test-library"...
Linking...
ld: error: undefined symbol: _D4core8internal7dassert__T14_d_assert_failTmZ__TQwTmZQBbFNaNbNiNfMxAyaKxmxmZAya
>>> referenced by package.d:4161 (/home/per/.local/ldc2-1.30.0-beta1-linux-x86_64/bin/../import/std/uni/package.d:4161)
>>>               .dub/build/mir-core-test-library-unittest-linux.posix-x86_64-ldc_v1.30.0-beta1-672186C08DFEB0FB7F91909AF105DE39/mir-core-test-library.o:(_D3std3uni__T4TrieTSQsQq__T9BitPackedTbVmi1ZQrTwVmi1114112TSQCgQCf__T9sliceBitsVmi13Vmi21ZQvTSQDoQDn__TQBiVmi8Vmi13ZQBvTSQEpQEo__TQCjVmi0Vmi8ZQCvZQFd__T7opIndexZQjMxFNaNbNiNewZb)
>>> referenced by write.d:3835 (/home/per/.local/ldc2-1.30.0-beta1-linux-x86_64/bin/../import/std/format/internal/write.d:3835)
>>>               .dub/build/mir-core-test-library-unittest-linux.posix-x86_64-ldc_v1.30.0-beta1-672186C08DFEB0FB7F91909AF105DE39/mir-core-test-library.o:(_D3std6format8internal5write__T5roundTG15aZQmFNaNbNiNfKQrmmEQCgQCfQCbQBv13RoundingClassbaZb)
>>> referenced by write.d:3833 (/home/per/.local/ldc2-1.30.0-beta1-linux-x86_64/bin/../import/std/format/internal/write.d:3833)
>>>               .dub/build/mir-core-test-library-unittest-linux.posix-x86_64-ldc_v1.30.0-beta1-672186C08DFEB0FB7F91909AF105DE39/mir-core-test-library.o:(_D3std6format8internal5write__T5roundTG15aZQmFNaNbNiNfKQrmmEQCgQCfQCbQBv13RoundingClassbaZb)
>>> referenced 17 more times
>>> did you mean: _D4core8internal7dassert__T14_d_assert_failTmZ__TQwTmZQBbFNaNbNiNfMxAyaKxmKxmZAya
>>> defined in: .dub/build/mir-core-test-library-unittest-linux.posix-x86_64-ldc_v1.30.0-beta1-672186C08DFEB0FB7F91909AF105DE39/mir-core-test-library.o
collect2: error: ld returned 1 exit status
Error: /usr/bin/cc failed with status: 1
/home/per/.local/ldc2-1.30.0-beta1-linux-x86_64/bin/ldc2 failed with exit code 1.
```

with both ldc and dmd.

The symbol

`_D4core8internal7dassert__T14_d_assert_failTmZ__TQwTmZQBbFNaNbNiNfMxAyaKxmxmZAya`

cannot even be demangled.

*Update*: Using `-allinst` aswell avoid the build errors.