### PR TITLE
meson: Allow building with gdc

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -6,6 +6,8 @@ subprojects = []
 
 has_cpp_headers = false
 
+dc = meson.get_compiler('d')
+
 sources_list = [
     'mir/algebraic',
     'mir/bitmanip',
@@ -36,10 +38,16 @@ foreach s : sources_list
     sources += 'source/' + s + '.d'
 endforeach
 
-add_project_arguments([
-    '-preview=dip1008',
-    '-lowmem',
-], language: 'd')
+if dc.get_id() == 'gcc'
+    add_project_arguments([
+        '-fpreview=dip1008',
+    ], language: 'd')
+else
+    add_project_arguments([
+        '-preview=dip1008',
+        '-lowmem',
+    ], language: 'd')
+endif
 
 required_deps = []
 


### PR DESCRIPTION
Hi!
This is just a tiny change to make this project build with GDC & Meson by using the right DIP preview flag when compiking with GDC.
It should address build failures on some architectures in Debian.
Cheers,
    Matthias
