### PR TITLE
workaround compiler bug, fix #63

### DIFF
--- a/source/mir/algebraic.d
+++ b/source/mir/algebraic.d
@@ -1475,7 +1475,7 @@ struct Algebraic(T__...)
     }
 
     /// Requires mir-algorithm package
-    immutable(char)[] toString()() @trusted pure scope const
+    immutable(char)[] toString()() @trusted scope const
     {
         static if (AllowedTypes.length == 0)
         {


### PR DESCRIPTION
Problem was that the user could pass in types that might not compile the same across all compilation units.

This might be related to https://issues.dlang.org/show_bug.cgi?id=23154 but not sure.

The `static if (__traits(compiles, { auto s = to!(immutable(char)[])(trustedGet!T);}))` was failing for me with

```
../../.dub/packages/mir-core-1.3.6/mir-core/source/mir/algebraic.d(1510,58): Error: `pure` function `mir.algebraic.Algebraic!(Json_).Algebraic.toString!().toString` cannot call impure function `mir.conv.to!string.to!(const(Algebraic!(Json_)[])).to`
../../.dub/packages/mir-core-1.3.6/mir-core/source/mir/algebraic.d(1510,58): Error: `pure` function `mir.algebraic.Algebraic!(Json_).Algebraic.toString!().toString` cannot call impure function `mir.conv.to!string.to!(const(U!(Algebraic!(Json_)))).to`
protocol/source/served/lsp/jsonops.d(50,11): Error: template instance `mir.algebraic.Algebraic!(Json_).Algebraic.toString!()` error instantiating
```

As templates already automatically infer their attributes, this shouldn't be a major breaking change. The `__traits(compiles)` rather looked like it would be inserted to check if the custom method can serialize to a string, not to check if it is pure doing so.