### PR TITLE
Fix typo in the GDC-specific implementation of 'copysign' function

### DIFF
--- a/source/mir/math/common.d
+++ b/source/mir/math/common.d
@@ -281,7 +281,7 @@ else version(GNU)
     ///
     T nearbyint(T)(in T x) if (isFloatingPoint!T) { mixin(mixinGCCBuiltin!`nearbyint`); }
     ///
-    T copysign(T)(in T mag, in T sgn) if (isFloatingPoint!T) { alias y = sgn; mixin(mixinGCCBuiltin2!`copysign`); }
+    T copysign(T)(in T x, in T sgn) if (isFloatingPoint!T) { alias y = sgn; mixin(mixinGCCBuiltin2!`copysign`); }
     ///
     T round(T)(in T x) if (isFloatingPoint!T) { mixin(mixinGCCBuiltin!`round`); }
     ///


### PR DESCRIPTION
Without this GDC 12.2.0 was failing to compile mir-algorithm:
```
../.dub/packages/mir-core-1.3.12/mir-core/source/mir/math/common.d-mixin-284:284:175: error: undefined identifier ‘x’
../.dub/packages/mir-algorithm-3.16.12/mir-algorithm/source/mir/format_impl.d:19:24: error: template instance ‘mir.math.common.copysign!double’ error instantiating
   19 |     bool neg = copysign(1, c) < 0;
      |                        ^
```