### PR TITLE
Avoid TLS variables in templates

### DIFF
--- a/source/mir/internal/meta.d
+++ b/source/mir/internal/meta.d
@@ -13,7 +13,7 @@ module mir.internal.meta;
 template getUDAs(T, string member, alias attribute)
 {
     import std.meta : Filter, AliasSeq;
-    T* aggregate;
+    private __gshared T* aggregate;
     static if (__traits(compiles, __traits(getAttributes, __traits(getMember, *aggregate, member))))
         alias getUDAs = Filter!(isDesiredUDA!attribute, __traits(getAttributes, __traits(getMember, *aggregate, member)));
     else

--- a/source/mir/reflection.d
+++ b/source/mir/reflection.d
@@ -804,7 +804,7 @@ private template SerdeFieldsAndPropertiesImpl(T)
     alias isProperty = ApplyLeft!(.isProperty, T);
     alias hasField = ApplyLeft!(.hasField, T);
     alias isOriginalMember = ApplyLeft!(.isOriginalMember, T);
-    T* aggregate;
+    private __gshared T* aggregate;
     template hasReflectSerde(string member)
     {
         static if (is(typeof(__traits(getMember, *aggregate, member))))


### PR DESCRIPTION
They are probably optimzed out anyway, but this cleans up the output when compiling with `-mtls` to print all TLS variables.