### PR TITLE
Do not include rvalue constructor in Algebraic if it already has a copy constructor

### DIFF
--- a/source/mir/algebraic.d
+++ b/source/mir/algebraic.d
@@ -1080,7 +1080,7 @@ struct Algebraic(T__...)
 
     /// Construct an algebraic type from its subset.
     this(RhsTypes...)(Algebraic!RhsTypes rhs)
-        if (allSatisfy!(Contains!AllowedTypes, Algebraic!RhsTypes.AllowedTypes))
+        if (!hasElaborateCopyConstructor!(Algebraic!T__)  && allSatisfy!(Contains!AllowedTypes, Algebraic!RhsTypes.AllowedTypes))
     {
         import core.lifetime: move;
         static if (is(RhsTypes == Types__))

--- a/source/mir/algebraic.d
+++ b/source/mir/algebraic.d
@@ -1080,7 +1080,7 @@ struct Algebraic(T__...)
 
     /// Construct an algebraic type from its subset.
     this(RhsTypes...)(Algebraic!RhsTypes rhs)
-        if (!hasElaborateCopyConstructor!(Algebraic!T__)  && allSatisfy!(Contains!AllowedTypes, Algebraic!RhsTypes.AllowedTypes))
+        if (!(hasElaborateCopyConstructor!(Algebraic!T__) && is(Algebraic!RhsTypes == typeof(this)))  && allSatisfy!(Contains!AllowedTypes, Algebraic!RhsTypes.AllowedTypes))
     {
         import core.lifetime: move;
         static if (is(RhsTypes == Types__))


### PR DESCRIPTION
This currently blocks: https://github.com/dlang/dmd/pull/13687

If this gets merged could a new tag be pushed so that buildkite gets unblocked?

Thanks!