### PR TITLE
Adjust anyEmpty to allow range.empty branch to get called

### DIFF
--- a/source/mir/primitives.d
+++ b/source/mir/primitives.d
@@ -117,7 +117,7 @@ package(mir) bool anyEmptyShape(size_t N)(scope const auto ref size_t[N] shape) 
 
 ///
 bool anyEmpty(Range)(scope const auto ref Range range) @property
-    if (hasShape!Range || __traits(hasMember, Range, "anyEmpty"))
+    if (hasShape!Range || __traits(hasMember, Range, "anyEmpty") || is(ReturnType!((Range r) => r.empty) == bool))
 {
     static if (__traits(hasMember, Range, "anyEmpty"))
     {


### PR DESCRIPTION
Based on discussion at https://github.com/libmir/mir-algorithm/issues/448. I use the same condition as `isInputRange` in testing for empty. 