### PR TITLE
Add overload of anyEmpty without const

### DIFF
--- a/source/mir/primitives.d
+++ b/source/mir/primitives.d
@@ -116,25 +116,6 @@ package(mir) bool anyEmptyShape(size_t N)(scope const auto ref size_t[N] shape) 
 }
 
 ///
-bool anyEmpty(Range)(scope const auto ref Range range) @property
-    if (hasShape!Range || __traits(hasMember, Range, "anyEmpty") || is(ReturnType!((Range r) => r.empty) == bool))
-{
-    static if (__traits(hasMember, Range, "anyEmpty"))
-    {
-        return range.anyEmpty;
-    }
-    else
-    static if (__traits(hasMember, Range, "shape"))
-    {
-        return anyEmptyShape(range.shape);
-    }
-    else
-    {
-        return range.empty;
-    }
-}
-
-///
 bool anyEmpty(Range)(scope auto ref Range range) @property
     if (hasShape!Range || __traits(hasMember, Range, "anyEmpty") || is(ReturnType!((Range r) => r.empty) == bool))
 {

--- a/source/mir/primitives.d
+++ b/source/mir/primitives.d
@@ -135,6 +135,25 @@ bool anyEmpty(Range)(scope const auto ref Range range) @property
 }
 
 ///
+bool anyEmpty(Range)(scope auto ref Range range) @property
+    if (hasShape!Range || __traits(hasMember, Range, "anyEmpty") || is(ReturnType!((Range r) => r.empty) == bool))
+{
+    static if (__traits(hasMember, Range, "anyEmpty"))
+    {
+        return range.anyEmpty;
+    }
+    else
+    static if (__traits(hasMember, Range, "shape"))
+    {
+        return anyEmptyShape(range.shape);
+    }
+    else
+    {
+        return range.empty;
+    }
+}
+
+///
 size_t elementCount(Range)(scope const auto ref Range range) @property
     if (hasShape!Range || __traits(hasMember, Range, "elementCount"))
 {


### PR DESCRIPTION
The prior PR fixing up `anyEmpty` does not resolve issue https://github.com/libmir/mir-algorithm/issues/448. The problem is that `anyEmpty` doesn't work for mutable ranges. If I add in a mutable version of `anyEmpty`, then that issue will be resolved. 