### PR TITLE
Fixup LightScopeOf

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ files
 mir-core-test-library
 bench_ldexp_frexp
 builddir
+*.pdb

--- a/source/mir/qualifier.d
+++ b/source/mir/qualifier.d
@@ -24,6 +24,10 @@ template LightScopeOf(T)
         static if (__traits(hasMember, T, "lightScope"))
             alias LightScopeOf = typeof(T.init.lightScope());
         else
+        static if (__traits(hasMember, TemplateArgsOf!T[0], "lightScope")) { // handles case where first template argument is RC
+            alias U = TemplateOf!T;
+            alias LightScopeOf = U!(typeof(TemplateArgsOf!T[0].init.lightScope()), TemplateArgsOf!T[1..$]);
+        } else
         static if (is(T == immutable))
             alias LightScopeOf = LightImmutableOf!T;
         else
@@ -32,6 +36,20 @@ template LightScopeOf(T)
         else
             alias LightScopeOf = T;
     }
+}
+
+@safe pure @nogc nothrow
+version(mir_core_test)
+unittest {
+    static struct Foo(T) {
+        T x;
+    }
+    static struct Bar(U) {
+        U y;
+        U lightScope() { return U.init;}
+    }
+    static assert(is(LightScopeOf!(Foo!double) == Foo!double));
+    static assert(is(LightScopeOf!(Foo!(Bar!double)) == Foo!double));
 }
 
 /++


### PR DESCRIPTION
Addressing issue https://github.com/libmir/mir-core/issues/86

I only handle the case where RCI would be the first element of the struct. It would be possible to make it more generic to handle other cases, but I think this would be the most common.