### PR TITLE
Trying to fix doc generation

### DIFF
--- a/source/mir/reflection.d
+++ b/source/mir/reflection.d
@@ -866,8 +866,7 @@ version(unittest)
     }
 }
 
-///
-version (mir_core_test) @nogc nothrow pure @safe version(mir_core_test) unittest
+version (mir_core_test) @nogc nothrow pure @safe unittest
 {
     static assert(!isPublic!(ZipArchive, "zip64ExtractVersion"));
 }


### PR DESCRIPTION
Make isPublic UT no longer documented since isPublic is package and causes CI to fail. Might add more if still failing